### PR TITLE
add undefined check on jsonString

### DIFF
--- a/src/simple-expand.js
+++ b/src/simple-expand.js
@@ -160,7 +160,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         // returns the cookie
         that.readCookie = function () {
             var jsonString = $.cookie(that.settings.cookieName);
-            if ( jsonString === null  || jsonString === '' ){
+            if ( jsonString === null  || jsonString === '' || jsonString === undefined ){
                 return {};
             }
             else{


### PR DESCRIPTION
I try to use keepStateInCookie but it gave me "JSON.parse: unexpected character at line 1 column 1 of the JSON data" error in the console although the jsonString has empty value. Adding check for undefined with jsonString fixes it. This is tested on Windows 7 and Firefox 30 browser.
